### PR TITLE
Add "combined_bound_check" pattern

### DIFF
--- a/.grit/patterns/combined_bound_check.md
+++ b/.grit/patterns/combined_bound_check.md
@@ -26,13 +26,19 @@ or {`$c1 and $c2`, `$c2 and $c1`} as $all where {
 # Two sided bound checks
 
 ```python
-x < 10 and x > 5
-100 >= my_var and my_var > -5
-x < get_strict_max() and get_min() <=  x
+if x < 10 and x > 5:
+    return "Ok"
+elif 100 >= my_var and my_var > -5:
+    return None
+else:
+    return (x < get_strict_max() and get_min() <=  x)
 ```
 
 ```python
-5 < x < 10
--5 < my_var <= 100
-get_min() <= x < get_strict_max()
+if 5 < x < 10:
+    return "Ok"
+elif -5 < my_var <= 100:
+    return None
+else:
+    return (get_min() <= x < get_strict_max())
 ```

--- a/.grit/patterns/combined_bound_check.md
+++ b/.grit/patterns/combined_bound_check.md
@@ -1,0 +1,38 @@
+---
+title: Combine upper and lower bound checks into a single check
+---
+
+Replaces 2 individual bound checks with a single combined bound check.
+
+```grit
+engine marzano(0.1)
+language python
+
+or {`$c1 and $c2`, `$c2 and $c1`} as $all where {
+    $upper_strict = "",
+    $lower_strict = "",
+    $c1 <:  or {
+        or {`$x < $upper`, `$upper > $x`}, 
+        or {`$x <= $upper`, `$upper >= $x`} where { $upper_strict = "=" }
+    } &&
+    $c2 <:  or {
+        or {`$x > $lower`, `$lower < $x`}, 
+        or {`$x >= $lower`, `$lower <= $x`} where { $lower_strict = "="}
+    },
+    $all => `$lower <$lower_strict $x <$upper_strict $upper`
+}
+```
+
+# Two sided bound checks
+
+```python
+x < 10 and x > 5
+100 >= my_var and my_var > -5
+x < get_strict_max() and get_min() <=  x
+```
+
+```python
+5 < x < 10
+-5 < my_var <= 100
+get_min() <= x < get_strict_max()
+```


### PR DESCRIPTION
Adds a new pattern that replaces 2 individual upper and lower bound checks with one combined bound check using [chained comparisons](https://docs.python.org/3/reference/expressions.html#comparisons).

This won't work if you have two objects that implement comparison strangely. E.g. if `(a < b) != (b > a)`, this rewrite will mess things up. In most cases though, I think it's an improvement