### PR TITLE
feat: use walrus operator instead of match and if

### DIFF
--- a/.grit/patterns/re_match_walrus.md
+++ b/.grit/patterns/re_match_walrus.md
@@ -2,18 +2,7 @@
 title: Walrus operator for match in if
 ---
 
-Use the walrus operator for snippets with the pattern:
-
-```python
-# Convert this:
-math = re.match(regex):
-if match:
-   ...
-
-# To this:
-if math := re.match(regex):
-   ...
-```
+Use the walrus operator for snippets with a match followed by an if.
 
 Limitations:
 * If the match function is imported with an alias (e.g. `from re import match as m`), it will not be transformed.
@@ -73,10 +62,9 @@ if_statement($alternative, $condition, $consequence) as $if where {
 
 ```
 
-## Transforms a log statement
+## Simple match and if
 
 ```python
-# re.match is transformed
 match = re.match("hello")
 if match:
     print("there is a match")
@@ -84,12 +72,43 @@ elif x > 10:
     print("no match")
 else:
     print("no match")
+```
 
-# re.fullmatch is transformed
+```python
+
+if match := re.match("hello"):
+    print("there is a match")
+elif x > 10:
+    print("no match")
+else:
+    print("no match")
+```
+
+## It also applies to search and fullmatch
+
+```python
 match = re.fullmatch("hello")
 if match:
     pass
 
+match = re.search("hello")
+if match:
+    pass
+```
+
+```python
+
+if match := re.fullmatch("hello"):
+    pass
+
+
+if match := re.search("hello"):
+    pass
+```
+
+## It only applies to functions in `re`
+
+```python
 # search is re.search and thus is transformed
 from re import search
 match = search("hello")
@@ -101,7 +120,25 @@ match = lambda s: False
 match = match("hello")
 if match:
     pass
+```
 
+```python
+# search is re.search and thus is transformed
+from re import search
+
+if match := search("hello"):
+    pass
+
+# match is not re.match and thus is not transformed
+match = lambda s: False
+match = match("hello")
+if match:
+    pass
+```
+
+## It does not apply to other `re` functions or from other modules
+
+```python
 # re.sub is not transformed
 sub = re.sub("hello", "bye")
 if sub:
@@ -114,32 +151,6 @@ if match:
 ```
 
 ```python
-# re.match is transformed
-
-if match := re.match("hello"):
-    print("there is a match")
-elif x > 10:
-    print("no match")
-else:
-    print("no match")
-
-# re.fullmatch is transformed
-
-if match := re.fullmatch("hello"):
-    pass
-
-# search is re.search and thus is transformed
-from re import search
-
-if match := search("hello"):
-    pass
-
-# match is not re.match and thus is not transformed
-match = lambda s: False
-match = match("hello")
-if match:
-    pass
-
 # re.sub is not transformed
 sub = re.sub("hello", "bye")
 if sub:

--- a/.grit/patterns/re_match_walrus.md
+++ b/.grit/patterns/re_match_walrus.md
@@ -28,14 +28,10 @@ pattern imported_match_function() {
     },
 }
 
-// TODO: we should also check if `re` is imported
 pattern explicit_match_function() {
     `re.$func` where {
         $func <: re_match_function()
     },
-    //$_ where {
-    //    $program <: contains `import re`,
-    //}
 }
 
 pattern match_function() {

--- a/.grit/patterns/re_match_walrus.md
+++ b/.grit/patterns/re_match_walrus.md
@@ -56,13 +56,11 @@ pattern match_function() {
     }
 }
 
-`$if` where {
+if_statement($alternative, $condition, $consequence) as $if where {
     $if <: after `$var = $match_func($regex)` => . where {
         $match_func <: match_function()
     },
-    $if <: if_statement($alternative, $condition, $consequence) where {
-        $condition <: `$var` => `$var := $match_func($regex)`
-    },
+    $condition <: `$var` => `$var := $match_func($regex)`,
     if ($alternative <: "") {
         $block = $consequence,
     }


### PR DESCRIPTION
Use the walrus operator for snippets with the pattern:

```python
# Convert this:
math = re.match(regex):
if match:
   ...

# To this:
if math := re.match(regex):
   ...
```

Limitations:
* If the match function is imported with an alias (e.g. `from re import match as m`), it will not be transformed.
* When `re.match` is used, we do not check that `re` comes from `import re`.