### PR TITLE
fix: multiple imports with `ensure_included()`

### DIFF
--- a/.grit/patterns/importing.md
+++ b/.grit/patterns/importing.md
@@ -100,12 +100,14 @@ pattern ensure_import_from($source) {
 
 pattern ensure_imported() {
     $name where {
-      and {
-        $program <: not contains python_import(source=$source) where {
-          $source = $name,
-        },
-        $GLOBAL_BARE_IMPORTS += [$name]
-      }
+        and {
+            $program <: not contains python_import(source=$name),
+            if ($GLOBAL_BARE_IMPORTS <: not some $name) {
+                $GLOBAL_BARE_IMPORTS += [$name]
+            } else {
+                true
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #24 

Also, I have observed that `ensure_included()` doesn't match when there are other top-level imports (see [this studio](https://app.grit.io/studio?key=BjMi9VGOPIlmLnYIdEa51) as an example).

However, there is one issue still pending: if there is an import like `from math import log`, and then you ensure the import of `math`, the pattern does not match. This has been reported as a separate issue: #26.