### PR TITLE
feat: add a global variant to OpenAI migration

### DIFF
--- a/.grit/patterns/openai.md
+++ b/.grit/patterns/openai.md
@@ -189,7 +189,7 @@ pattern pytest_patch() {
 pattern openai_main($client) {
     $body where {
         if ($client <: undefined) {
-            $need_openai_import = `true`,
+            $need_openai_import = `false`,
             $create_client = true,
         } else {
             $need_openai_import = `true`,

--- a/.grit/patterns/openai.md
+++ b/.grit/patterns/openai.md
@@ -186,14 +186,14 @@ pattern pytest_patch() {
     },
 }
 
-pattern openai_main($use_global_client) {
+pattern openai_main($client) {
     $body where {
-        if ($use_global_client <: undefined) {
+        if ($client <: undefined) {
             $need_openai_import = `true`,
-            $use_global_client = `false`,
+            $create_client = true,
         } else {
             $need_openai_import = `true`,
-            $client = `openai`,
+            $create_client = false,
         },
         $has_openai_import = `false`,
         $has_partial_import = `false`,
@@ -224,7 +224,7 @@ pattern openai_main($use_global_client) {
             }
         },
 
-        if ($use_global_client <: `false`) {
+        if ($create_client <: true) {
             if ($has_openai_import <: `true`) {
                 $import_stmt <: change_import($has_sync, $has_async, $need_openai_import),
                 if ($has_partial_import <: `true`) {
@@ -241,7 +241,8 @@ pattern openai_main($use_global_client) {
 }
 
 file($body) where {
-    $body <: openai_main(use_global_client=true)
+  // No client means instantiate one per file
+  $body <: openai_main()
 }
 ```
 

--- a/.grit/patterns/openai.md
+++ b/.grit/patterns/openai.md
@@ -61,15 +61,23 @@ pattern deprecated_resource_cls() {
 }
 
 
-pattern rename_func($has_sync, $has_async, $res, $stmt, $params) {
+pattern rename_func($has_sync, $has_async, $res, $stmt, $params, $client) {
     $func where {
         if ($func <: r"a([a-zA-Z0-9]+)"($func_rest)) {
             $has_async = `true`,
             $func => $func_rest,
-            $stmt => `aclient.$res.$func($params)`,
+            if ($client <: undefined) {
+                $stmt => `aclient.$res.$func($params)`,
+            } else {
+                $stmt => `$client.$res.$func($params)`,
+            }
         } else {
             $has_sync = `true`,
-            $stmt => `client.$res.$func($params)`,
+            if ($client <: undefined) {
+                $stmt => `client.$res.$func($params)`,
+            } else {
+                $stmt => `$client.$res.$func($params)`,
+            }
         },
         // Fix function renames
         if ($res <: `Image`) {
@@ -107,11 +115,11 @@ pattern change_import($has_sync, $has_async, $need_openai_import) {
     }
 }
 
-pattern rewrite_whole_fn_call($import, $has_sync, $has_async, $res, $func, $params, $stmt, $body) {
+pattern rewrite_whole_fn_call($import, $has_sync, $has_async, $res, $func, $params, $stmt, $body, $client) {
     or {
         rename_resource() where {
             $import = `true`,
-            $func <: rename_func($has_sync, $has_async, $res, $stmt, $params),
+            $func <: rename_func($has_sync, $has_async, $res, $stmt, $params, $client),
         },
         deprecated_resource() as $dep_res where {
             $stmt_whole = $stmt,
@@ -178,48 +186,62 @@ pattern pytest_patch() {
     },
 }
 
+pattern openai_main($use_global_client) {
+    $body where {
+        if ($use_global_client <: undefined) {
+            $need_openai_import = `true`,
+            $use_global_client = `false`,
+        } else {
+            $need_openai_import = `true`,
+            $client = `openai`,
+        },
+        $has_openai_import = `false`,
+        $has_partial_import = `false`,
+        $has_sync = `false`,
+        $has_async = `false`,
+
+        // Remap errors
+        $body <: maybe contains `openai.error.$exp` => `openai.$exp` where {
+            $need_openai_import = `true`,
+        },
+
+        // Mark all the places where we they configure openai as something that requires manual intervention
+        $body <: maybe contains bubble($need_openai_import) `openai.$field = $val` => `raise Exception("The 'openai.$field' option isn't read in the client API. You will need to pass it when you instantiate the client, e.g. 'OpenAI($field=$val)'")` where {
+            $need_openai_import = `true`,
+        },
+
+        $body <: maybe contains `import openai` as $import_stmt where {
+            $body <: contains bubble($has_sync, $has_async, $has_openai_import, $body, $client) `openai.$res.$func($params)` as $stmt where {
+                $res <: rewrite_whole_fn_call(import = $has_openai_import, $has_sync, $has_async, $res, $func, $params, $stmt, $body, $client),
+            },
+        },
+
+        $body <: maybe contains `from openai import $resources` as $partial_import_stmt where {
+            $has_partial_import = `true`,
+            $body <: contains bubble($has_sync, $has_async, $resources, $client) `$res.$func($params)` as $stmt where {
+                $resources <: contains $res,
+                $res <: rewrite_whole_fn_call($import, $has_sync, $has_async, $res, $func, $params, $stmt, $body, $client),
+            }
+        },
+
+        if ($use_global_client <: `false`) {
+            if ($has_openai_import <: `true`) {
+                $import_stmt <: change_import($has_sync, $has_async, $need_openai_import),
+                if ($has_partial_import <: `true`) {
+                    $partial_import_stmt => .,
+                },
+            } else if ($has_partial_import <: `true`) {
+                $partial_import_stmt <: change_import($has_sync, $has_async, $need_openai_import),
+            },
+        },
+
+        $body <: maybe contains unittest_patch(),
+        $body <: maybe contains pytest_patch(),
+    }
+}
+
 file($body) where {
-    $need_openai_import = `false`,
-    $has_openai_import = `false`,
-    $has_partial_import = `false`,
-    $has_sync = `false`,
-    $has_async = `false`,
-
-    // Remap errors
-    $body <: maybe contains `openai.error.$exp` => `openai.$exp` where {
-        $need_openai_import = `true`,
-    },
-
-    // Mark all the places where we they configure openai as something that requires manual intervention
-    $body <: maybe contains bubble($need_openai_import) `openai.$field = $val` => `raise Exception("The 'openai.$field' option isn't read in the client API. You will need to pass it when you instantiate the client, e.g. 'OpenAI($field=$val)'")` where {
-        $need_openai_import = `true`,
-    },
-
-    $body <: maybe contains `import openai` as $import_stmt where {
-        $body <: contains bubble($has_sync, $has_async, $has_openai_import, $body) `openai.$res.$func($params)` as $stmt where {
-            $res <: rewrite_whole_fn_call(import = $has_openai_import, $has_sync, $has_async, $res, $func, $params, $stmt, $body),
-        },
-    },
-
-    $body <: maybe contains `from openai import $resources` as $partial_import_stmt where {
-        $has_partial_import = `true`,
-        $body <: contains bubble($has_sync, $has_async, $resources) `$res.$func($params)` as $stmt where {
-            $resources <: contains $res,
-            $res <: rewrite_whole_fn_call($import, $has_sync, $has_async, $res, $func, $params, $stmt, $body),
-        }
-    },
-
-    if ($has_openai_import <: `true`) {
-        $import_stmt <: change_import($has_sync, $has_async, $need_openai_import),
-        if ($has_partial_import <: `true`) {
-            $partial_import_stmt => .,
-        },
-    } else if ($has_partial_import <: `true`) {
-        $partial_import_stmt <: change_import($has_sync, $has_async, $need_openai_import),
-    },
-
-    $body <: maybe contains unittest_patch(),
-    $body <: maybe contains pytest_patch(),
+    $body <: openai_main(use_global_client=true)
 }
 ```
 

--- a/.grit/patterns/openai.md
+++ b/.grit/patterns/openai.md
@@ -205,9 +205,11 @@ pattern openai_main($client) {
             $need_openai_import = `true`,
         },
 
-        // Mark all the places where we they configure openai as something that requires manual intervention
-        $body <: maybe contains bubble($need_openai_import) `openai.$field = $val` => `raise Exception("The 'openai.$field' option isn't read in the client API. You will need to pass it when you instantiate the client, e.g. 'OpenAI($field=$val)'")` where {
-            $need_openai_import = `true`,
+        if ($client <: undefined) {
+          // Mark all the places where we they configure openai as something that requires manual intervention
+          $body <: maybe contains bubble($need_openai_import) `openai.$field = $val` => `raise Exception("The 'openai.$field' option isn't read in the client API. You will need to pass it when you instantiate the client, e.g. 'OpenAI($field=$val)'")` where {
+              $need_openai_import = `true`,
+          },
         },
 
         $body <: maybe contains `import openai` as $import_stmt where {

--- a/.grit/patterns/openai_global.md
+++ b/.grit/patterns/openai_global.md
@@ -65,13 +65,10 @@ except openai.error.RateLimitError as err:
 
 ```python
 import openai
-from openai import OpenAI
-
-client = OpenAI()
 
 try:
-    completion = client.completions.create(model="davinci-002", prompt="Hello world")
-    chat_completion = client.chat.completions.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Hello world"}])
+    completion = openai.completions.create(model="davinci-002", prompt="Hello world")
+    chat_completion = openai.chat.completions.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Hello world"}])
 except openai.RateLimitError as err:
     pass
 ```

--- a/.grit/patterns/openai_global.md
+++ b/.grit/patterns/openai_global.md
@@ -2,7 +2,7 @@
 title: Upgrade to OpenAI Python SDK - Global Client
 ---
 
-Convert OpenAI from openai version to the v1 version, while continuing to use the global client
+Convert OpenAI from openai version to the v1 version, while continuing to use the global client. This is a variant of the [client-based version](https://github.com/getgrit/python/blob/main/.grit/patterns/openai.md).
 
 tags: #python, #openai, #migration
 

--- a/.grit/patterns/openai_global.md
+++ b/.grit/patterns/openai_global.md
@@ -72,21 +72,3 @@ try:
 except openai.RateLimitError as err:
     pass
 ```
-
-## Image creation has been renamed
-
-The `Image.create` method has been renamed to `image.generate`.
-
-```python
-import openai
-
-openai.Image.create(file=file)
-```
-
-```python
-from openai import OpenAI
-
-client = OpenAI()
-
-client.images.generate(file=file)
-```

--- a/.grit/patterns/openai_global.md
+++ b/.grit/patterns/openai_global.md
@@ -1,0 +1,95 @@
+---
+title: Upgrade to OpenAI Python SDK - Global Client
+---
+
+Convert OpenAI from openai version to the v1 version, while continuing to use the global client
+
+tags: #python, #openai, #migration
+
+```grit
+engine marzano(0.1)
+language python
+
+file($body) where {
+  $body <: openai_main(client=`openai`)
+}
+```
+
+## Rewrite completions
+
+```python
+import openai
+
+completion = await openai.Completion.acreate(model="davinci-002", prompt="Hello world")
+chat_completion = await openai.ChatCompletion.acreate(model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Hello world"}])
+```
+
+```python
+import openai
+
+completion = await openai.completions.create(model="davinci-002", prompt="Hello world")
+chat_completion = await openai.chat.completions.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Hello world"}])
+```
+
+## Global settings
+
+If you use the global client, options can be set on itself.
+
+```python
+import openai
+
+if openai_proxy:
+    openai.proxy = openai_proxy
+    openai.api_base = self.openai_api_base
+```
+
+```python
+import openai
+
+if openai_proxy:
+    openai.proxy = openai_proxy
+    openai.api_base = self.openai_api_base
+```
+
+## Remap errors
+
+```python
+import openai
+
+try:
+    completion = openai.Completion.create(model="davinci-002", prompt="Hello world")
+    chat_completion = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Hello world"}])
+except openai.error.RateLimitError as err:
+    pass
+```
+
+```python
+import openai
+from openai import OpenAI
+
+client = OpenAI()
+
+try:
+    completion = client.completions.create(model="davinci-002", prompt="Hello world")
+    chat_completion = client.chat.completions.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Hello world"}])
+except openai.RateLimitError as err:
+    pass
+```
+
+## Image creation has been renamed
+
+The `Image.create` method has been renamed to `image.generate`.
+
+```python
+import openai
+
+openai.Image.create(file=file)
+```
+
+```python
+from openai import OpenAI
+
+client = OpenAI()
+
+client.images.generate(file=file)
+```


### PR DESCRIPTION
The new SDK actually still packages a global client, which is a lower lift (though not recommended) for users who have lots of global config.

Closes https://github.com/getgrit/rewriter/issues/7839