### PR TITLE
chore: snippets aren't strings

### DIFF
--- a/.grit/patterns/importing.md
+++ b/.grit/patterns/importing.md
@@ -104,7 +104,7 @@ pattern ensure_bare_import() {
 and {
     before_each_file(),
     contains or {
-        import_from(source=`pydantic`) => .,
+        import_from(source="pydantic") => .,
         `$testlib.TestCase` where {
             $newtest = `newtest`,
             $testlib <: `unittest` => `$newtest`,

--- a/.grit/patterns/re_match_walrus.md
+++ b/.grit/patterns/re_match_walrus.md
@@ -24,7 +24,7 @@ pattern re_match_function() {
 pattern imported_match_function() {
     $func where {
         $func <: re_match_function(),
-        $func <: is_imported_from(source = `re`),
+        $func <: is_imported_from(source = "re"),
     },
 }
 


### PR DESCRIPTION
required for yaml equivalence classes